### PR TITLE
Add Diff Language themeing

### DIFF
--- a/peterbosak.e-ink-1.0.0/themes/E-Ink-color-theme.json
+++ b/peterbosak.e-ink-1.0.0/themes/E-Ink-color-theme.json
@@ -716,5 +716,31 @@
         "foreground": "#000000"
       }
     },
+    {
+      "name": "Diff Inserted",
+      "scope": [
+        "markup.inserted",
+        "punctuation.definition.inserted.diff",
+        "punctuation.definition.to-file.diff",
+        "meta.diff.header.to-file"
+      ],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#888888",
+      }
+    },
+    {
+      "name": "Diff Deleted",
+      "scope": [
+        "markup.deleted",
+        "punctuation.definition.deleted.diff",
+        "punctuation.definition.from-file.diff",  
+        "meta.diff.header.from-file"
+      ],
+      "settings": {
+        "fontStyle": "strikethrough",
+        "foreground": "#bbbbbb"
+      }
+    },
   ]
 }


### PR DESCRIPTION
Prior to this change, a .diff file showed up as plain text even with the Diff language selected. With this change, all removals will be greyed out with a strikethrough treatment and additions will be less black with a bold treatment.
![image](https://github.com/Mufanza/vs-code-e-ink-theme/assets/526491/59b654d8-0d83-47b5-9565-1a37da748bd7)
